### PR TITLE
fix: globally install pkg-size with npm

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7805,8 +7805,7 @@ async function Qc({checkoutRef: e, refData: t, buildCommand: r}) {
     }
     if (!Zc) {
         Y.info("Installing pkg-size globally");
-        await Vc("yarn global add pkg-size");
-        Y.addPath((await Vc("yarn global bin")).stdout.trim());
+        await Vc("npm i -g pkg-size");
         Zc = true;
     }
     Y.info("Getting package size");

--- a/src/lib/build-ref.js
+++ b/src/lib/build-ref.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import { addPath } from '@actions/core';
 import * as log from './log.js';
 import exec from './exec.js';
 import npmCi from './npm-ci.js';
@@ -62,8 +61,7 @@ async function buildRef({
 
 	if (!pkgSizeInstalled) {
 		log.info('Installing pkg-size globally');
-		await exec('yarn global add pkg-size');
-		addPath((await exec('yarn global bin')).stdout.trim());
+		await exec('npm i -g pkg-size');
 		pkgSizeInstalled = true;
 	}
 


### PR DESCRIPTION
Was previously getting the following error:

```
  Build script found in package.json
  No lock file detected. Installing dependencies with npm
  Running build command: npm run build
  Build completed in 0.2s
  Installing pkg-size globally
  Error: The process '/usr/local/bin/yarn' failed with exit code 1
  Warning: Error: The process '/usr/local/bin/yarn' failed with exit code 1
      at Bc._setResult (/home/runner/work/_actions/pkg-size/action/v1/dist/index.js:7611:21)
      at Bc.CheckComplete (/home/runner/work/_actions/pkg-size/action/v1/dist/index.js:7597:18)
      at ChildProcess.<anonymous> (/home/runner/work/_actions/pkg-size/action/v1/dist/index.js:7496:23)
      at ChildProcess.emit (events.js:210:5)
      at maybeClose (internal/child_process.js:1021:16)
      at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)
```

Seems `addPath` has [become deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) for security reasons.

Also doesn't seem like `npm i -g` requires `sudo` or `actions/setup-node` as a prerequisite anymore, based on experiment.